### PR TITLE
add post-transaction hooks for mkinitcpio.conf updating

### DIFF
--- a/libalpm/hooks/50-bootsplash.hook
+++ b/libalpm/hooks/50-bootsplash.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Remove
+Type = Package
+Target = bootsplash-theme-*
+
+[Action]
+Description = Update bootsplash themes
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/bootsplash-hooks

--- a/libalpm/scripts/bootsplash-hooks
+++ b/libalpm/scripts/bootsplash-hooks
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+ 
+# Let's search for installed themes
+echo "Searching for available themes..."
+themes=()
+for i in /usr/lib/initcpio/install/bootsplash-*; do
+    themes+=(`basename $i`)
+done
+  
+# So what have we found there?
+if [ "${#themes[*]}" == "0" ]; then                 
+    echo "No themes found"
+else
+    echo "Found ${#themes[*]} themes"
+fi
+
+# Now let's look inside the mkinitcpio.conf and get the HOOKS list
+echo "Checking mkinitcpio.conf ..."
+hooks=(`cat /etc/mkinitcpio.conf | grep '^HOOKS' | sed "s/HOOKS=\"//; s/\"/ /; s/ /\n/g; s/bootsplash-.*\s//g"`)            # without any themes
+ 
+# We also want to know what themes are already included
+themes_included=(`cat /etc/mkinitcpio.conf | grep '^HOOKS' | sed 's/HOOKS="//; s/"/ /; s/ /\n/g' | grep "bootsplash-"`)     # themes only
+  
+# Compare found and included theme lists to understand if we need to edit mkinitcpio.conf
+# If lists are equal - there's nothing to do
+if [[ "${#themes_included[*]}" == "${#themes[*]}" && -z "$(echo ${themes[@]} ${themes_included[@]} | tr ' ' '\n' | sort | uniq -u)" ]]; then                                                           
+    echo "HOOKS are OK"
+ 
+# If not - we will cynchronize HOOKS with available themes list
+else
+    cp /etc/mkinitcpio.conf /etc/mkinitcpio.conf.bak
+    echo -e "Updated/deleted themes detected\nSynchronizing HOOKS..."
+    sed -i "/^HOOKS=\".*\"/c HOOKS=\"$(echo ${hooks[@]} ${themes[@]} | tr ' ' '\  ')\"" /etc/mkinitcpio.conf
+fi


### PR DESCRIPTION
Now mkinitcpio.conf can be updated automatically when user installs/removes bootsplash-theme-* packages.
